### PR TITLE
Line chart markers

### DIFF
--- a/packages/charts/package-lock.json
+++ b/packages/charts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@canvas-sdk/charts",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@canvas-sdk/charts",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.3.3"

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canvas-sdk/charts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "url": "git+https://github.com/canvas/sdk.git",
     "directory": "packages/charts"

--- a/packages/charts/src/chart.tsx
+++ b/packages/charts/src/chart.tsx
@@ -22,6 +22,7 @@ export function Chart({
   y,
   sizes,
   type,
+  svgClassName,
   width: argWidth,
   height = 300,
   options = {},
@@ -30,6 +31,7 @@ export function Chart({
   y: TableColumn;
   sizes?: number[];
   type: "line" | "bar" | "bubble";
+  svgClassName?: string;
   width?: number;
   height?: number;
   options?: ChartOptions;
@@ -84,7 +86,7 @@ export function Chart({
 
   return (
     <div ref={sizeDivRef} className="w-full flex-1">
-      <svg width={width} height={height}>
+      <svg width={width} height={height} className={svgClassName}>
         {type === "line" && (
           <g style={{ stroke: "currentColor" }}>
             <LineChart

--- a/packages/charts/src/line.tsx
+++ b/packages/charts/src/line.tsx
@@ -63,7 +63,6 @@ export function LineChart<DomainValue extends Ordinal>({
       <g
         className={className}
         style={{
-          filter: "drop-shadow(0px 0px 16px currentColor)",
           strokeWidth: 2,
           stroke: "currentColor",
           fill: "none",

--- a/packages/charts/src/line.tsx
+++ b/packages/charts/src/line.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { Fragment, ReactElement } from "react";
 import { Scale } from "./lib/types";
 import { Data, Ordinal } from "./lib/types";
 import { lineTo, moveCursorTo, roundPixel } from "./svg/path";
@@ -16,6 +16,7 @@ export function LineChart<DomainValue extends Ordinal>({
   className?: string;
   options?: {
     gradient?: string;
+    showMarkers?: boolean;
   };
 }): ReactElement {
   const gradient = options?.gradient;
@@ -25,6 +26,10 @@ export function LineChart<DomainValue extends Ordinal>({
   const paths: string[][] = new Array(seriesCount).fill(null).map((_) => {
     return [];
   });
+
+  const markers: { x: number; y: number }[][] = paths.map((_) => []);
+  const showMarkers = options?.showMarkers ?? data.length <= 5;
+
   data.forEach((point, pointIndex) => {
     const values = Array.isArray(point.y) ? point.y : [point.y];
 
@@ -43,6 +48,12 @@ export function LineChart<DomainValue extends Ordinal>({
       const path = paths[valueIndex];
       if (path) {
         path.push(command);
+      }
+
+      if (showMarkers) {
+        if (markers[valueIndex]) {
+          markers[valueIndex].push({ x, y });
+        }
       }
     });
   });
@@ -66,6 +77,29 @@ export function LineChart<DomainValue extends Ordinal>({
           );
         })}
       </g>
+      {showMarkers ? (
+        <g>
+          {markers.map((series, index) => {
+            const cssColor = `var(--chart-color-${index}, currentcolor)`;
+
+            return (
+              <Fragment key={index}>
+                {series.map((point, index) => {
+                  return (
+                    <circle
+                      key={index}
+                      r={3.5}
+                      cx={point.x}
+                      cy={point.y}
+                      style={{ fill: cssColor, stroke: "none" }}
+                    />
+                  );
+                })}
+              </Fragment>
+            );
+          })}
+        </g>
+      ) : null}
       {gradient && (
         <g className={className} /*filter="url(#noise)"*/>
           {paths.map((path, index) => {

--- a/packages/charts/src/scale/datetime.ts
+++ b/packages/charts/src/scale/datetime.ts
@@ -50,7 +50,6 @@ export function dateTimeScale(
   bandWidth = Math.max(2, bandWidth);
 
   function size(domainValue: Date) {
-    console.log({ domainValue, domainMin, domainWidth });
     const domainPos =
       (domainValue.getTime() - (domainMin?.getTime() ?? 0)) / domainWidth;
     return domainPos * (rangeWidth - bandWidth);

--- a/packages/charts/src/scale/datetime.ts
+++ b/packages/charts/src/scale/datetime.ts
@@ -1,58 +1,78 @@
-import { Scale } from '../lib/types';
+import { Scale } from "../lib/types";
 
-export function dateTimeScale(domain: Date[], range: [number, number]): Scale<Date> | null {
-    const sortedDomain = [...domain];
-    sortedDomain.sort((a, b) => a.getTime() - b.getTime());
+export function dateTimeScale(
+  domain: Date[],
+  range: [number, number]
+): Scale<Date> | null {
+  const sortedDomain = [...domain];
+  sortedDomain.sort((a, b) => a.getTime() - b.getTime());
 
-    const domainMin = sortedDomain[0];
-    const domainMax = sortedDomain[sortedDomain.length - 1];
+  const domainMin = sortedDomain[0];
+  const domainMax = sortedDomain[sortedDomain.length - 1];
 
-    const [rangeMin, rangeMax] = range;
+  const [rangeMin, rangeMax] = range;
 
-    if (domainMin === undefined || domainMax === undefined) {
-        return null;
+  if (domainMin === undefined || domainMax === undefined) {
+    return null;
+  }
+
+  const ticks: Date[] = [];
+  const dateRangeDays =
+    Math.abs(domainMax.getTime() - domainMin.getTime()) / 1000 / 60 / 60 / 24;
+  if (dateRangeDays > 700) {
+    for (
+      let year = domainMin.getFullYear() + 1;
+      year <= domainMax.getFullYear();
+      year += 1
+    ) {
+      ticks.push(new Date(year, 0, 1));
     }
+  } else {
+    const tickCount = 6;
 
-    const ticks: Date[] = [];
-    const dateRangeDays = Math.abs(domainMax.getTime() - domainMin.getTime()) / 1000 / 60 / 60 / 24;
-    if (dateRangeDays > 700) {
-        for (let year = domainMin.getFullYear() + 1; year <= domainMax.getFullYear(); year += 1) {
-            ticks.push(new Date(year, 0, 1));
-        }
-    } else {
-        const tickCount = 6;
+    const tickDelta = Math.floor(dateRangeDays / (tickCount - 1));
 
-        const tickDelta = Math.floor(dateRangeDays / (tickCount - 1));
-
-        for (let i = 0; i < (tickCount - 1); i += 1) {
-            const tick = new Date(domainMin);
-            tick.setDate(domainMin.getDate() + tickDelta * (i + 0.5));
-            if (tick.getTime() > domainMax.getTime()) {
-                break;
-            }
-            ticks.push(tick);
-        }
+    for (let i = 0; i < tickCount - 1; i += 1) {
+      const tick = new Date(domainMin);
+      tick.setDate(domainMin.getDate() + tickDelta * (i + 0.5));
+      if (tick.getTime() > domainMax.getTime()) {
+        break;
+      }
+      ticks.push(tick);
     }
+  }
 
-    const rangeWidth = rangeMax - rangeMin;
-    const domainWidth = domainMax.getTime() - domainMin.getTime();
+  const rangeWidth = rangeMax - rangeMin;
+  const domainWidth = (domainMax.getTime() - domainMin.getTime()) || 1;
 
-    let bandWidth = rangeWidth / (domainWidth / (1000 * 60 * 60 * 24 * 30));
-    bandWidth = Math.min(bandWidth, rangeWidth / domain.length);
-    bandWidth = Math.max(2, bandWidth);
+  let bandWidth = rangeWidth / (domainWidth / (1000 * 60 * 60 * 24 * 30));
+  bandWidth = Math.min(bandWidth, rangeWidth / domain.length);
+  bandWidth = Math.max(2, bandWidth);
 
-    function size(domainValue: Date) {
-        const domainPos = (domainValue.getTime() - (domainMin?.getTime() ?? 0)) / domainWidth;
-        return domainPos * (rangeWidth - bandWidth);
-    }
+  function size(domainValue: Date) {
+    console.log({ domainValue, domainMin, domainWidth });
+    const domainPos =
+      (domainValue.getTime() - (domainMin?.getTime() ?? 0)) / domainWidth;
+    return domainPos * (rangeWidth - bandWidth);
+  }
 
-    function position(domainValue: Date) {
-        return size(domainValue) + rangeMin;
-    }
+  function position(domainValue: Date) {
+    return size(domainValue) + rangeMin;
+  }
 
-    function midPoint(domainValue: Date) {
-        return position(domainValue) + bandWidth / 2;
-    }
+  function midPoint(domainValue: Date) {
+    return position(domainValue) + bandWidth / 2;
+  }
 
-    return { size, position, midPoint, ticks, bandWidth, domainMin, domainMax, rangeMin, rangeMax };
+  return {
+    size,
+    position,
+    midPoint,
+    ticks,
+    bandWidth,
+    domainMin,
+    domainMax,
+    rangeMin,
+    rangeMax,
+  };
 }

--- a/packages/charts/src/scale/linear.ts
+++ b/packages/charts/src/scale/linear.ts
@@ -53,7 +53,7 @@ export function numberScale(
         }
     }
 
-    const tickCount = Math.min(simpleAxisThreshold, domain.length);
+    const tickCount = 5;
 
     let tickMax = domainMax;
     if (lastTick === 'trim' && domain.length > simpleAxisThreshold) {


### PR DESCRIPTION
Add line chart markers for line charts with data.length <= 5. This also fixes the confusing case of data.length == 1 (which without markers looks empty)


<img width="1408" alt="Screenshot 2024-08-07 at 11 10 43 PM" src="https://github.com/user-attachments/assets/e3c66b6f-ab84-45e5-94c9-e63d50f80db8">
